### PR TITLE
Increase mailing delay to 200ms from 100ms

### DIFF
--- a/src/AppMailRelay/Mailer.cs
+++ b/src/AppMailRelay/Mailer.cs
@@ -158,7 +158,7 @@ namespace AppMailRelay
                             _cacheOptions
                         );
 
-                        Task.Delay(100).Wait();
+                        Task.Delay(200).Wait();
                     }
 
                     client.Disconnect(true);


### PR DESCRIPTION
AWS has a rate limit on sending email. I believe we accidentally hit that limit when sending bulk emails. 

Increasing the timeout from 100ms (10 emails per second) to 200ms (5 emails per second) in an attempt to avoid hitting that limit again. 